### PR TITLE
Fixed Issue #65: Markers attach to an XMachine or an XContext 

### DIFF
--- a/ac.soton.xeventb.feature/feature.properties
+++ b/ac.soton.xeventb.feature/feature.properties
@@ -35,10 +35,15 @@ Release history:\n\
 ---------------\n\
 ### 2.1.0 Usability Update  ###\n\
 #### Updated Plug-ins/Features ####\n\
+- XContext (2.1.0): Attach the markers to the XContext's name if no child \
+element found (see Issue #65).\n\
+- XMachine (2.1.0): Attach the markers to the XMachine's name if no child \
+element found (see Issue #65).\n\
 - CamilleX UI (1.1.0): Added a context menu item to do the batch generation of \
-CamilleX source files.\n\
+CamilleX source files (see Issue #63).\n\
 #### Fixed Issues ####\n\
 - Issue #63: Batch generation for a collection of CamilleX source files.\n\
+- Issue #65: Markers attach to an XMachine or an XContext.\n\
 ### 2.0.2 Maintenance release ###\n\
 - Fixed the Update Site name.\n\
 - Removed the included features: Inclusion, Records, Containment\n\

--- a/ac.soton.xeventb.sdk/feature.properties
+++ b/ac.soton.xeventb.sdk/feature.properties
@@ -35,6 +35,8 @@ Release history:\n\
 ### 2.1.0 Usability Update ###\n\
 #### Updated Plug-ins/Features ####\n\
 - CamilleX Feature (2.1.0)\n\
+- XContext Source (2.1.0): Generated\n\
+- XMachine Source (2.1.0): Generated\n\
 - CamilleX UI Source (1.1.0): Generated \n\
 ### 2.0.2 Maintenance release ###\n\
 - Fixed Update Site name.\n\

--- a/ac.soton.xeventb.xcontext/META-INF/MANIFEST.MF
+++ b/ac.soton.xeventb.xcontext/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
-Bundle-Version: 2.0.2.release
+Bundle-Version: 2.1.0.qualifier
 Bundle-SymbolicName: ac.soton.xeventb.xcontext;singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eventb.emf.core;bundle-version="[5.0.0,6.0.0)",

--- a/ac.soton.xeventb.xcontext/src/ac/soton/xeventb/xcontext/validation/XContextValidator.xtend
+++ b/ac.soton.xeventb.xcontext/src/ac/soton/xeventb/xcontext/validation/XContextValidator.xtend
@@ -1,13 +1,13 @@
 /*******************************************************************************
  * Copyright (c) 2017,2021 University of Southampton.
- *
+ * 
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * https://www.eclipse.org/legal/epl-2.0/
- *
+ * 
  * SPDX-License-Identifier: EPL-2.0
- *
+ * 
  * Contributors:
  *     University of Southampton - initial API and implementation
  *******************************************************************************/
@@ -28,11 +28,13 @@ import org.eventb.core.ICarrierSet
 import org.eventb.core.IConstant
 import org.eventb.core.IContextRoot
 import org.eventb.emf.core.CorePackage
+import org.eventb.emf.core.EventBObject
 import org.eventb.emf.core.EventBPredicate
 import org.eventb.emf.core.context.Axiom
 import org.eventb.emf.core.context.CarrierSet
 import org.eventb.emf.core.context.Constant
 import org.eventb.emf.core.context.Context
+import org.eventb.emf.core.context.ContextPackage
 import org.eventb.emf.persistence.EventBEMFUtils
 import org.rodinp.core.IAttributeType
 import org.rodinp.core.IRodinElement
@@ -43,7 +45,7 @@ import org.rodinp.keyboard.core.RodinKeyboardCore
  * <p>
  * XContext validator, provides custom validation rules for the XContexts.
  * </p>
- *
+ * 
  * @author dana - Initial Implementation
  * @author htson - Added support for lifting Rodin issues into XContext
  * @version 1.1
@@ -51,266 +53,268 @@ import org.rodinp.keyboard.core.RodinKeyboardCore
  * @see XContextMarkerModule
  */
 class XContextValidator extends AbstractXContextValidator {
-	
-   	/**
-   	 * Check to ensure that the context name match the name of the file.
-   	 * 
-   	 * @author dana
-   	 * @author htson - Renamed from "checkMachineName"
-   	 * @since 2.0
-   	 */
-   	@Check
-	def checkContextName(Context ctx){
-		val res = ctx.eResource
-		val fileName = res.URI.lastSegment.toString
-		val ctxName= fileName.substring(0, fileName.indexOf('.'))
-		if (ctxName != ctx.name)
-			error('Context name should be the same as the file name', null) 
-	}
 
-	/**
-	 * Check for untranslated predicates by comparing the translated string
-	 * with the predicate. Raise a warning with code
-	 * {@link IValidationIssueCode#UNTRANSLATE_PREDICATE}. The code is used for
-	 * providing quick fixes.
-	 * 
-	 * @param obj 
-	 * 		an Event-B predicate EObject.
-	 * @author htson
-	 * @see IValidationIssueCode
-	 * @since 2.0
-	 */
-	@Check
-	def untranslatedPredicate(EventBPredicate obj) {
-		val predicate = obj.predicate
-		val translated = RodinKeyboardCore.translate(predicate)
-		if (predicate != translated)
-			warning("Untranslated Predicate: " + predicate, obj,
-				CorePackage.Literals.EVENT_BPREDICATE__PREDICATE,
-				IValidationIssueCode.UNTRANSLATED_PREDICATE, predicate, translated
-			)
-	}
+    /**
+     * Check to ensure that the context name match the name of the file.
+     * 
+     * @author dana
+     * @author htson - Renamed from "checkMachineName"
+     * @since 2.0
+     */
+    @Check
+    def checkContextName(Context ctx) {
+        val res = ctx.eResource
+        val fileName = res.URI.lastSegment.toString
+        val ctxName = fileName.substring(0, fileName.indexOf('.'))
+        if (ctxName != ctx.name)
+            error('Context name should be the same as the file name', null)
+    }
 
-	/**
-	 * A "Normal" check to clear the markers associated with the Rodin context.
-	 * This is important as the markers generated as the consequence of
-	 * @link{#checkRodinMarkers(Context)} are not cleared by when the file is
-	 * saved (hence they prevent the generator to run).
-	 * 
-	 * @author htson
-	 * @since 2.0
-	 */
-	@Check(NORMAL)
-	def clearRodinMarkers(Context ctx) {
-		// htson: This clear all markers associated with the XContext file.
-		// We probably should register a new marker type and clear only those.
-		val uri = ctx.eResource.URI
-		val resource = ResourcesPlugin.workspace.root.getFile(
-			new Path(uri.toPlatformString(true))
-		)
-		val markers = resource.findMarkers(null, true,
-				IResource.DEPTH_INFINITE);
-		for (marker : markers)
-			marker.delete
-	}
+    /**
+     * Check for untranslated predicates by comparing the translated string
+     * with the predicate. Raise a warning with code
+     * {@link IValidationIssueCode#UNTRANSLATE_PREDICATE}. The code is used for
+     * providing quick fixes.
+     * 
+     * @param obj 
+     * 		an Event-B predicate EObject.
+     * @author htson
+     * @see IValidationIssueCode
+     * @since 2.0
+     */
+    @Check
+    def untranslatedPredicate(EventBPredicate obj) {
+        val predicate = obj.predicate
+        val translated = RodinKeyboardCore.translate(predicate)
+        if (predicate != translated)
+            warning(
+                "Untranslated Predicate: " + predicate,
+                obj,
+                CorePackage.Literals.EVENT_BPREDICATE__PREDICATE,
+                IValidationIssueCode.UNTRANSLATED_PREDICATE,
+                predicate,
+                translated
+            )
+    }
 
-	/**
-	 * Empty array of markers.
-	 * 
-	 * @since 2.0
-	 */
-	val IMarker[] NO_MARKER = #[];
+    /**
+     * A "Normal" check to clear the markers associated with the Rodin context.
+     * This is important as the markers generated as the consequence of
+     * @link{#checkRodinMarkers(Context)} are not cleared by when the file is
+     * saved (hence they prevent the generator to run).
+     * 
+     * @author htson
+     * @since 2.0
+     */
+    @Check(NORMAL)
+    def clearRodinMarkers(Context ctx) {
+        // htson: This clear all markers associated with the XContext file.
+        // We probably should register a new marker type and clear only those.
+        val uri = ctx.eResource.URI
+        val resource = ResourcesPlugin.workspace.root.getFile(
+            new Path(uri.toPlatformString(true))
+        )
+        val markers = resource.findMarkers(null, true, IResource.DEPTH_INFINITE);
+        for (marker : markers)
+            marker.delete
+    }
 
-	/**
-	 * An "expensive" check to convert the Rodin Markers of an input Rodin
-	 * machine into issues for the corresponding XMachine.
-	 * 
-	 * @param mch
-	 * 			The input Rodini machine
-	 * 
-	 * @author htson
-	 * @since 2.0
-	 */
-	@Check(EXPENSIVE)
-	def checkRodinMarkers(Context ctx) {
-		val ctxRoot = EventBEMFUtils.getRoot(ctx)
-		val rodinMarkers = findRodinMarkers(ctxRoot)
-		for (rodinMarker : rodinMarkers) {
-			val rodinElement = RodinMarkerUtil.getElement(rodinMarker)
-			var obj = getEObject(ctx, rodinElement)
-			if (obj === null)
-				obj = ctx
-			createIssue(obj, rodinMarker)
-		}
-	}
+    /**
+     * Empty array of markers.
+     * 
+     * @since 2.0
+     */
+    val IMarker[] NO_MARKER = #[];
 
-	/**
-	 * Utility method to find all Rodin markers associated with a machine root.
-	 * @param mchRoot
-	 * 			The input machine root.
-	 * 
-	 * @return An array of the Rodin markers associated with the input machine
-	 * root.
-	 * 
-	 * @author htson
-	 * @since 2.0 
-	 */
-	def private IMarker[] findRodinMarkers(IContextRoot ctxRoot)
-			throws CoreException {
-		val resource = ctxRoot.getResource();
-		if (!resource.isAccessible()) {
-			return NO_MARKER;
-		}
-		return resource.findMarkers(RodinMarkerUtil.RODIN_PROBLEM_MARKER, true,
-				IResource.DEPTH_INFINITE);
-	}
+    /**
+     * An "expensive" check to convert the Rodin Markers of an input Rodin
+     * machine into issues for the corresponding XMachine.
+     * 
+     * @param mch
+     * 			The input Rodini machine
+     * 
+     * @author htson
+     * @since 2.0
+     */
+    @Check(EXPENSIVE)
+    def checkRodinMarkers(Context ctx) {
+        val ctxRoot = EventBEMFUtils.getRoot(ctx)
+        val rodinMarkers = findRodinMarkers(ctxRoot)
+        for (rodinMarker : rodinMarkers) {
+            val rodinElement = RodinMarkerUtil.getElement(rodinMarker)
+            var obj = getEObject(ctx, rodinElement)
+            if (obj === null)
+                obj = ctx
+            createIssue(obj, rodinMarker)
+        }
+    }
 
-	/**
-	 * Method to find the EObject in a machine corresponding to the input Rodin
-	 * object. This is the "identified" attribute such as "identifier", "label".
-	 * 
-	 * @param mch
-	 *			The input machine
-	 * @param rodinElement
-	 * 			The input Rodin element
-	 * @return the EObject corresponding to the input Rodin element within the
-	 *  		input machine or <code>null</code>  
-	 *
-	 */
-	// TODO These methods probably should go into EMFEventBUtils
-	def private EObject getEObject(Context ctx, IRodinElement rodinElement) {
-		if (rodinElement instanceof IContextRoot) {
-			return ctx
-		}
-		if (rodinElement instanceof ICarrierSet) {
-			return findCarrierSet(ctx, rodinElement.identifierString)			
-		}
-		if (rodinElement instanceof IConstant) {
-			return findConstant(ctx, rodinElement.identifierString)
-		}
-		if (rodinElement instanceof IAxiom) {
-			return findAxiom(ctx, rodinElement.label)
-		}
-		return null
-	}
+    /**
+     * Utility method to find all Rodin markers associated with a machine root.
+     * @param mchRoot
+     * 			The input machine root.
+     * 
+     * @return An array of the Rodin markers associated with the input machine
+     * root.
+     * 
+     * @author htson
+     * @since 2.0 
+     */
+    def private IMarker[] findRodinMarkers(IContextRoot ctxRoot) throws CoreException {
+        val resource = ctxRoot.getResource();
+        if (!resource.isAccessible()) {
+            return NO_MARKER;
+        }
+        return resource.findMarkers(RodinMarkerUtil.RODIN_PROBLEM_MARKER, true, IResource.DEPTH_INFINITE);
+    }
 
-	def private CarrierSet findCarrierSet(Context ctx, String name) {
-		val sets = ctx.sets
-		for (set : sets) {
-			if (set.name == name)
-				return set
-		}
-		return null
-	}
+    /**
+     * Method to find the EObject in a machine corresponding to the input Rodin
+     * object. This is the "identified" attribute such as "identifier", "label".
+     * 
+     * @param mch
+     * 		The input machine
+     * @param rodinElement
+     * 			The input Rodin element
+     * @return the EObject corresponding to the input Rodin element within the
+     *  		input machine or <code>null</code>  
+     * 
+     */
+    // TODO These methods probably should go into EMFEventBUtils
+    def private EObject getEObject(Context ctx, IRodinElement rodinElement) {
+        if (rodinElement instanceof IContextRoot) {
+            return ctx
+        }
+        if (rodinElement instanceof ICarrierSet) {
+            return findCarrierSet(ctx, rodinElement.identifierString)
+        }
+        if (rodinElement instanceof IConstant) {
+            return findConstant(ctx, rodinElement.identifierString)
+        }
+        if (rodinElement instanceof IAxiom) {
+            return findAxiom(ctx, rodinElement.label)
+        }
+        return null
+    }
 
-	def private Constant findConstant(Context ctx, String name) {
-		val csts = ctx.constants
-		for (cst : csts) {
-			if (cst.name == name)
-				return cst
-		}
-		return null
-	}
+    def private CarrierSet findCarrierSet(Context ctx, String name) {
+        val sets = ctx.sets
+        for (set : sets) {
+            if (set.name == name)
+                return set
+        }
+        return null
+    }
 
-	def private Axiom findAxiom(Context ctx, String label) {
-		val axms = ctx.axioms
-		for (axm : axms) {
-			if (axm.name == label)
-				return axm
-		}
-		return null
-	}
+    def private Constant findConstant(Context ctx, String name) {
+        val csts = ctx.constants
+        for (cst : csts) {
+            if (cst.name == name)
+                return cst
+        }
+        return null
+    }
 
-	/**
-	 * Utility method to create an issue associated with an EObject from a Rodin
-	 * marker associated with the Rodin element corresponding to the EObject.
-	 * 
-	 * @param obj
-	 * 			The input EObject
-	 * @param rodinMarker
-	 * 			The input Rodin marker.
-	 * @author htson
-	 * @since 2.0
-	 */
-	def private createIssue(EObject obj, IMarker rodinMarker) {
-		val attributeType = RodinMarkerUtil.getAttributeType(rodinMarker);
-		val attributes = rodinMarker.attributes
-		val severity = attributes.get(IMarker.SEVERITY)
+    def private Axiom findAxiom(Context ctx, String label) {
+        val axms = ctx.axioms
+        for (axm : axms) {
+            if (axm.name == label)
+                return axm
+        }
+        return null
+    }
+
+    /**
+     * Utility method to create an issue associated with an EObject from a Rodin
+     * marker associated with the Rodin element corresponding to the EObject.
+     * 
+     * @param obj
+     * 			The input EObject
+     * @param rodinMarker
+     * 			The input Rodin marker.
+     * @author htson
+     * @since 2.0
+     */
+    def private createIssue(EObject obj, IMarker rodinMarker) {
+        val attributeType = RodinMarkerUtil.getAttributeType(rodinMarker);
+        val attributes = rodinMarker.attributes
+        val severity = attributes.get(IMarker.SEVERITY)
         var message = attributes.get(IMarker.MESSAGE)
-		
+
         var feature = getFeature(obj, attributeType)
-        var elem = obj
+        var elem = obj       
         if (feature === null) {
             elem = getContext(obj)
             if (elem !== null)
                 feature = CorePackage.Literals.EVENT_BNAMED__NAME
             else
-               elem = obj
+                elem = obj
         } else {
-    		// XText markers does not have information about "start" and "end"
-	       	// at the moment. We include this information in the message and
-    		// "decode" it later when create the markers. 
+            // XText markers does not have information about "start" and "end"
+            // at the moment. We include this information in the message and
+            // "decode" it later when create the markers. 
             val start = RodinMarkerUtil.getCharStart(rodinMarker)
             val end = RodinMarkerUtil.getCharEnd(rodinMarker)
             if (start != -1) {
                 message = message + " (from " + start + " to " + end + ")"
             }
-		}
-		if (severity == IMarker.SEVERITY_ERROR)
-			error(message.toString, elem, feature)
-		else if (severity == IMarker.SEVERITY_WARNING)
-			warning(message.toString, elem, feature)
-		else
-			info(message.toString, elem, feature)
-	}
+        }
+        if (severity == IMarker.SEVERITY_ERROR)
+            error(message.toString, elem, feature)
+        else if (severity == IMarker.SEVERITY_WARNING)
+            warning(message.toString, elem, feature)
+        else
+            info(message.toString, elem, feature)
+    }
 
-	/**
-	 * Utility method to get the EStructuralFeature corresponding to an
-	 * attribute of an input EObject (of some Event-B elements), given the
-	 * attribute type.
-	 * 
-	 * @param obj
-	 * 			The input EObject
-	 * @param attributeType
-	 * 			The input attribute type
-	 * @return The EStructuralFeature corresponding to the Attribute Type for
-	 * 			the EObject. If no EStructuralFeature exists, return
-	 * 			<code>null</code>. 
-	 * 
-	 * @author htson
-	 * @since 2.0
-	 */
-	// TODO This is probably incomplete
-	def private EStructuralFeature getFeature(EObject obj,
-		IAttributeType attributeType // This is the Rodin Attribute Type
-	) {
-		if (attributeType === null)
-			return null
-		val id = attributeType.id
-		if (obj instanceof CarrierSet) {
-			// "Identifier" for carrier sets will be "name"
-			if (id == "org.eventb.core.identifier")
-				return CorePackage.Literals.EVENT_BNAMED__NAME
-			return null
-		}
-		if (obj instanceof Constant) {
-			// "Identifier" for constants will be "name"
-			if (id == "org.eventb.core.identifier")
-				return CorePackage.Literals.EVENT_BNAMED__NAME
-			return null
-		}
-		if (obj instanceof Axiom) {
-			// "Identifier" for variables will be "name"
-			if (id == "org.eventb.core.label")
-				return CorePackage.Literals.EVENT_BNAMED__NAME
-			if (id == "org.eventb.core.predicate")
-				return CorePackage.Literals.EVENT_BPREDICATE__PREDICATE
-			return null
-		}
-		return null
-	}
-	
-	/**
+    /**
+     * Utility method to get the EStructuralFeature corresponding to an
+     * attribute of an input EObject (of some Event-B elements), given the
+     * attribute type.
+     * 
+     * @param obj
+     * 			The input EObject
+     * @param attributeType
+     * 			The input attribute type
+     * @return The EStructuralFeature corresponding to the Attribute Type for
+     * 			the EObject. If no EStructuralFeature exists, return
+     * 			<code>null</code>. 
+     * 
+     * @author htson
+     * @since 2.0
+     */
+    // TODO This is probably incomplete
+    def private EStructuralFeature getFeature(
+        EObject obj,
+        IAttributeType attributeType // This is the Rodin Attribute Type
+    ) {
+        if (attributeType === null)
+            return null
+        val id = attributeType.id
+        if (obj instanceof CarrierSet) {
+            // "Identifier" for carrier sets will be "name"
+            if (id == "org.eventb.core.identifier")
+                return CorePackage.Literals.EVENT_BNAMED__NAME
+            return null
+        }
+        if (obj instanceof Constant) {
+            // "Identifier" for constants will be "name"
+            if (id == "org.eventb.core.identifier")
+                return CorePackage.Literals.EVENT_BNAMED__NAME
+            return null
+        }
+        if (obj instanceof Axiom) {
+            // "Identifier" for variables will be "name"
+            if (id == "org.eventb.core.label")
+                return CorePackage.Literals.EVENT_BNAMED__NAME
+            if (id == "org.eventb.core.predicate")
+                return CorePackage.Literals.EVENT_BPREDICATE__PREDICATE
+            return null
+        }
+        return null
+    }
+
+    /**
      * Utility method to get the context of an EObject. Return the Context 
      * parent of the input element. Return <code>null</code> if there is no
      * Context containing the input element.
@@ -320,18 +324,10 @@ class XContextValidator extends AbstractXContextValidator {
      * @author htson
      * @since 2.1
      */
-     def EObject getContext(EObject object) {
-        if (object instanceof Context)
-            return object
-        if (object instanceof CarrierSet)
-            return object.eContainer
-        if (object instanceof Constant)
-            return object.eContainer
-        if (object instanceof Axiom)
-            return object.eContainer
-        
+    def EObject getContext(EObject object) {
+        if (object instanceof EventBObject)
+            return object.getContaining(ContextPackage.Literals.CONTEXT)
         return null
     }
 
-	
 }

--- a/ac.soton.xeventb.xcontext/xtend-gen/ac/soton/xeventb/xcontext/validation/XContextValidator.java
+++ b/ac.soton.xeventb.xcontext/xtend-gen/ac/soton/xeventb/xcontext/validation/XContextValidator.java
@@ -37,11 +37,13 @@ import org.eventb.core.ICarrierSet;
 import org.eventb.core.IConstant;
 import org.eventb.core.IContextRoot;
 import org.eventb.emf.core.CorePackage;
+import org.eventb.emf.core.EventBObject;
 import org.eventb.emf.core.EventBPredicate;
 import org.eventb.emf.core.context.Axiom;
 import org.eventb.emf.core.context.CarrierSet;
 import org.eventb.emf.core.context.Constant;
 import org.eventb.emf.core.context.Context;
+import org.eventb.emf.core.context.ContextPackage;
 import org.eventb.emf.persistence.EventBEMFUtils;
 import org.rodinp.core.IAttributeType;
 import org.rodinp.core.IRodinElement;
@@ -98,7 +100,8 @@ public class XContextValidator extends AbstractXContextValidator {
     final String translated = RodinKeyboardCore.translate(predicate);
     boolean _notEquals = (!Objects.equal(predicate, translated));
     if (_notEquals) {
-      this.warning(("Untranslated Predicate: " + predicate), obj, 
+      this.warning(
+        ("Untranslated Predicate: " + predicate), obj, 
         CorePackage.Literals.EVENT_BPREDICATE__PREDICATE, 
         IValidationIssueCode.UNTRANSLATED_PREDICATE, predicate, translated);
     }
@@ -121,8 +124,7 @@ public class XContextValidator extends AbstractXContextValidator {
       String _platformString = uri.toPlatformString(true);
       Path _path = new Path(_platformString);
       final IFile resource = _root.getFile(_path);
-      final IMarker[] markers = resource.findMarkers(null, true, 
-        IResource.DEPTH_INFINITE);
+      final IMarker[] markers = resource.findMarkers(null, true, IResource.DEPTH_INFINITE);
       for (final IMarker marker : markers) {
         marker.delete();
       }
@@ -186,8 +188,7 @@ public class XContextValidator extends AbstractXContextValidator {
     if (_not) {
       return this.NO_MARKER;
     }
-    return resource.findMarkers(RodinMarkerUtil.RODIN_PROBLEM_MARKER, true, 
-      IResource.DEPTH_INFINITE);
+    return resource.findMarkers(RodinMarkerUtil.RODIN_PROBLEM_MARKER, true, IResource.DEPTH_INFINITE);
   }
   
   /**
@@ -195,7 +196,7 @@ public class XContextValidator extends AbstractXContextValidator {
    * object. This is the "identified" attribute such as "identifier", "label".
    * 
    * @param mch
-   * 			The input machine
+   * 		The input machine
    * @param rodinElement
    * 			The input Rodin element
    * @return the EObject corresponding to the input Rodin element within the
@@ -371,17 +372,8 @@ public class XContextValidator extends AbstractXContextValidator {
    * @since 2.1
    */
   public EObject getContext(final EObject object) {
-    if ((object instanceof Context)) {
-      return object;
-    }
-    if ((object instanceof CarrierSet)) {
-      return ((CarrierSet)object).eContainer();
-    }
-    if ((object instanceof Constant)) {
-      return ((Constant)object).eContainer();
-    }
-    if ((object instanceof Axiom)) {
-      return ((Axiom)object).eContainer();
+    if ((object instanceof EventBObject)) {
+      return ((EventBObject)object).getContaining(ContextPackage.Literals.CONTEXT);
     }
     return null;
   }

--- a/ac.soton.xeventb.xcontext/xtend-gen/ac/soton/xeventb/xcontext/validation/XContextValidator.java
+++ b/ac.soton.xeventb.xcontext/xtend-gen/ac/soton/xeventb/xcontext/validation/XContextValidator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017,2020 University of Southampton.
+ * Copyright (c) 2017,2021 University of Southampton.
  * 
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -54,8 +54,10 @@ import org.rodinp.keyboard.core.RodinKeyboardCore;
  * </p>
  * 
  * @author dana - Initial Implementation
- * @version 0.1
+ * @author htson - Added support for lifting Rodin issues into XContext
+ * @version 1.1
  * @since 1.0
+ * @see XContextMarkerModule
  */
 @SuppressWarnings("all")
 public class XContextValidator extends AbstractXContextValidator {
@@ -269,29 +271,39 @@ public class XContextValidator extends AbstractXContextValidator {
   private void createIssue(final EObject obj, final IMarker rodinMarker) {
     try {
       final IAttributeType attributeType = RodinMarkerUtil.getAttributeType(rodinMarker);
-      final EStructuralFeature feature = this.getFeature(obj, attributeType);
       final Map<String, Object> attributes = rodinMarker.getAttributes();
       final Object severity = attributes.get(IMarker.SEVERITY);
-      final int start = RodinMarkerUtil.getCharStart(rodinMarker);
-      final int end = RodinMarkerUtil.getCharEnd(rodinMarker);
       Object message = attributes.get(IMarker.MESSAGE);
-      if ((start != (-1))) {
-        String _plus = (message + " (from ");
-        String _plus_1 = (_plus + Integer.valueOf(start));
-        String _plus_2 = (_plus_1 + " to ");
-        String _plus_3 = (_plus_2 + Integer.valueOf(end));
-        String _plus_4 = (_plus_3 + ")");
-        message = _plus_4;
+      EStructuralFeature feature = this.getFeature(obj, attributeType);
+      EObject elem = obj;
+      if ((feature == null)) {
+        elem = this.getContext(obj);
+        if ((elem != null)) {
+          feature = CorePackage.Literals.EVENT_BNAMED__NAME;
+        } else {
+          elem = obj;
+        }
+      } else {
+        final int start = RodinMarkerUtil.getCharStart(rodinMarker);
+        final int end = RodinMarkerUtil.getCharEnd(rodinMarker);
+        if ((start != (-1))) {
+          String _plus = (message + " (from ");
+          String _plus_1 = (_plus + Integer.valueOf(start));
+          String _plus_2 = (_plus_1 + " to ");
+          String _plus_3 = (_plus_2 + Integer.valueOf(end));
+          String _plus_4 = (_plus_3 + ")");
+          message = _plus_4;
+        }
       }
       boolean _equals = Objects.equal(severity, Integer.valueOf(IMarker.SEVERITY_ERROR));
       if (_equals) {
-        this.error(message.toString(), obj, feature);
+        this.error(message.toString(), elem, feature);
       } else {
         boolean _equals_1 = Objects.equal(severity, Integer.valueOf(IMarker.SEVERITY_WARNING));
         if (_equals_1) {
-          this.warning(message.toString(), obj, feature);
+          this.warning(message.toString(), elem, feature);
         } else {
-          this.info(message.toString(), obj, feature);
+          this.info(message.toString(), elem, feature);
         }
       }
     } catch (Throwable _e) {
@@ -344,6 +356,32 @@ public class XContextValidator extends AbstractXContextValidator {
         return CorePackage.Literals.EVENT_BPREDICATE__PREDICATE;
       }
       return null;
+    }
+    return null;
+  }
+  
+  /**
+   * Utility method to get the context of an EObject. Return the Context
+   * parent of the input element. Return <code>null</code> if there is no
+   * Context containing the input element.
+   * 
+   * @param obj
+   *          The input EObject
+   * @author htson
+   * @since 2.1
+   */
+  public EObject getContext(final EObject object) {
+    if ((object instanceof Context)) {
+      return object;
+    }
+    if ((object instanceof CarrierSet)) {
+      return ((CarrierSet)object).eContainer();
+    }
+    if ((object instanceof Constant)) {
+      return ((Constant)object).eContainer();
+    }
+    if ((object instanceof Axiom)) {
+      return ((Axiom)object).eContainer();
     }
     return null;
   }

--- a/ac.soton.xeventb.xmachine/META-INF/MANIFEST.MF
+++ b/ac.soton.xeventb.xmachine/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
-Bundle-Version: 2.0.2.release
+Bundle-Version: 2.1.0.qualifier
 Bundle-SymbolicName: ac.soton.xeventb.xmachine;singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.xtext;bundle-version="[2.13.0,3.0.0)",

--- a/ac.soton.xeventb.xmachine/src/ac/soton/xeventb/xmachine/validation/XMachineValidator.xtend
+++ b/ac.soton.xeventb.xmachine/src/ac/soton/xeventb/xmachine/validation/XMachineValidator.xtend
@@ -1,13 +1,13 @@
 /*******************************************************************************
  *  Copyright (c) 2017,2020 University of Southampton.
- *
+ * 
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
  *  which accompanies this distribution, and is available at
  *  https://www.eclipse.org/legal/epl-2.0/
- *
+ * 
  *  SPDX-License-Identifier: EPL-2.0
- *
+ * 
  *  Contributors:
  *    University of Southampton - initial API and implementation
  *******************************************************************************/
@@ -35,12 +35,14 @@ import org.eventb.core.IVariable
 import org.eventb.emf.core.CorePackage
 import org.eventb.emf.core.EventBAction
 import org.eventb.emf.core.EventBExpression
+import org.eventb.emf.core.EventBObject
 import org.eventb.emf.core.EventBPredicate
 import org.eventb.emf.core.machine.Action
 import org.eventb.emf.core.machine.Event
 import org.eventb.emf.core.machine.Guard
 import org.eventb.emf.core.machine.Invariant
 import org.eventb.emf.core.machine.Machine
+import org.eventb.emf.core.machine.MachinePackage
 import org.eventb.emf.core.machine.Parameter
 import org.eventb.emf.core.machine.Variable
 import org.eventb.emf.core.machine.Variant
@@ -55,7 +57,7 @@ import org.rodinp.keyboard.core.RodinKeyboardCore
  * <p>
  * XMachine validator, provides custom validation rules for the xtext machine file.
  * </p>
- *
+ * 
  * @author dana - Initial implementation
  * @author htson - Added support for lifting Rodin issues into XMachine
  * @version 1.1
@@ -65,236 +67,236 @@ import org.rodinp.keyboard.core.RodinKeyboardCore
 class XMachineValidator extends AbstractXMachineValidator {
 
     // Check the name of the .bumx file is the same as the machine name
-	@Check
-	def checkMachineName(Machine mch){
-		val res = mch.eResource
-		val fileName = res.URI.lastSegment.toString
-		val mchName= fileName.substring(0, fileName.indexOf('.'))
-		if (mchName != mch.name)
-			error('Machine name should be the same as the file name', null) //MachinePackage.Literals.MACHINE.eContainingFeature
-	}
-	
-	/**
-	 * check the prefix of the event must be one of the prefixes of the included machine
-	 * that contains the synchronised event
-	 * 
-	 * @since 1.0
-	 */
-	@Check
-	def checkEventPrefix(EventSynchronisation evt){
-		if(!evt.prefix.empty){
-			val prefix = evt.prefix
-			val mchContainer = evt.eContainer.eContainer as Machine
-			
-			for(ext: mchContainer.extensions){
-				if(ext instanceof MachineInclusion ){
-					val events = (ext as MachineInclusion).abstractMachine.events
-					if((events).contains(evt.synchronisedEvent)){//used abstract machine as scoping
-						if((ext as MachineInclusion).prefixes.contains(prefix)){
-							return
-						}
-					}
-				}
-			}
-			error('Event prefix must be one of the included machine prefixes', null)
-		}
-	}
-	
+    @Check
+    def checkMachineName(Machine mch) {
+        val res = mch.eResource
+        val fileName = res.URI.lastSegment.toString
+        val mchName = fileName.substring(0, fileName.indexOf('.'))
+        if (mchName != mch.name)
+            error('Machine name should be the same as the file name', null) // MachinePackage.Literals.MACHINE.eContainingFeature
+    }
+
+    /**
+     * check the prefix of the event must be one of the prefixes of the included machine
+     * that contains the synchronised event
+     * 
+     * @since 1.0
+     */
+    @Check
+    def checkEventPrefix(EventSynchronisation evt) {
+        if (!evt.prefix.empty) {
+            val prefix = evt.prefix
+            val mchContainer = evt.eContainer.eContainer as Machine
+
+            for (ext : mchContainer.extensions) {
+                if (ext instanceof MachineInclusion) {
+                    val events = (ext as MachineInclusion).abstractMachine.events
+                    if ((events).contains(evt.synchronisedEvent)) { // used abstract machine as scoping
+                        if ((ext as MachineInclusion).prefixes.contains(prefix)) {
+                            return
+                        }
+                    }
+                }
+            }
+            error('Event prefix must be one of the included machine prefixes', null)
+        }
+    }
+
     /**
      * Add Prefixing warning if more than one machine is inlcuded
-	 * the  reason is to avoid event synchronisation problems if machines have the same event name e.g. INITIALISATION
-	 * 
-	 * @since 1.0
-	 */
-	@Check
-	def checkMachinePrefix(Machine mch){
-	    val mchExtensions = mch.extensions.filter(MachineInclusion)
-	    
-		if(mchExtensions.size > 1) {
-			for(inc: mchExtensions){
-				if (inc.prefixes.empty)
-					warning('Prefixing is not defined for ' + inc.abstractMachine.name + '. Possible synchronisation ambiguity. ', null)
-			}
-		}
-	}
-	
-	/**
-	 * Check the prefix of the event must be one of the prefixes of the included machine
-	 * that contains the synchronised event
-	 * 
-	 * @since 1.0
-	 */
-	@Check
-	def checkEventPrefixEmpty(EventSynchronisation evt){
-		System.out.println("Check event prefix empty")
-	
-		if(evt.prefix.empty){
-			val mchContainer = evt.eContainer.eContainer as Machine
-			val mchIncExtensions = mchContainer.extensions.filter(MachineInclusion)
-			for(ext : mchIncExtensions){
-				if(ext.abstractMachine.events.contains(evt.synchronisedEvent)){
-					if(ext.prefixes.empty)
-						return
-					else
-						warning('Prefixing should be applied to the synchronised event.', null)
-				}
-			}
-		}
-	}
+     * the  reason is to avoid event synchronisation problems if machines have the same event name e.g. INITIALISATION
+     * 
+     * @since 1.0
+     */
+    @Check
+    def checkMachinePrefix(Machine mch) {
+        val mchExtensions = mch.extensions.filter(MachineInclusion)
 
-	/**
-	 * Empty array of markers.
-	 * 
-	 * @since 2.0
-	 */
-	val IMarker[] NO_MARKER = #[];
+        if (mchExtensions.size > 1) {
+            for (inc : mchExtensions) {
+                if (inc.prefixes.empty)
+                    warning('Prefixing is not defined for ' + inc.abstractMachine.name +
+                        '. Possible synchronisation ambiguity. ', null)
+            }
+        }
+    }
 
-	/**
-	 * Utility method to find all Rodin markers associated with a machine root.
-	 * @param mchRoot
-	 * 			The input machine root.
-	 * 
-	 * @return An array of the Rodin markers associated with the input machine
-	 * root.
-	 * 
-	 * @author htson
-	 * @since 2.0 
-	 */
-	def private IMarker[] findRodinMarkers(IMachineRoot mchRoot)
-			throws CoreException {
-		val resource = mchRoot.getResource();
-		if (!resource.isAccessible()) {
-			return NO_MARKER;
-		}
-		return resource.findMarkers(RodinMarkerUtil.RODIN_PROBLEM_MARKER, true,
-				IResource.DEPTH_INFINITE);
-	}
+    /**
+     * Check the prefix of the event must be one of the prefixes of the included machine
+     * that contains the synchronised event
+     * 
+     * @since 1.0
+     */
+    @Check
+    def checkEventPrefixEmpty(EventSynchronisation evt) {
+        System.out.println("Check event prefix empty")
 
-	/**
-	 * Utility method to get the EStructuralFeature corresponding to an
-	 * attribute of an input EObject (of some Event-B elements), given the
-	 * attribute type.
-	 * 
-	 * @param obj
-	 * 			The input EObject
-	 * @param attributeType
-	 * 			The input attribute type
-	 * @return The EStructuralFeature corresponding to the Attribute Type for
-	 * 			the EObject. If no EStructuralFeature exists, return
-	 * 			<code>null</code>. 
-	 * 
-	 * @author htson
-	 * @since 2.0
-	 */
-	// TODO This is probably incomplete
-	def private EStructuralFeature getFeature(EObject obj,
-		IAttributeType attributeType // This is the Rodin Attribute Type
-	) {
-	 	// TODO Colin: Is there a better way to do this
-		if (attributeType === null)
-			return null
-		val id = attributeType.id
-		if (obj instanceof Variable) {
-			// "Identifier" for variables will be "name"
-			if (id == "org.eventb.core.identifier")
-				return CorePackage.Literals.EVENT_BNAMED__NAME
-			return null
-		}
-		if (obj instanceof Invariant) {
-			// "Label" for invariants will be "name"
-			if (id == "org.eventb.core.label") {
-				return CorePackage.Literals.EVENT_BNAMED__NAME
-			}
-			// "Predicate" for invariants will be "predicate"
-			if (id == "org.eventb.core.predicate") {
-				return CorePackage.Literals.EVENT_BPREDICATE__PREDICATE				
-			}
-			return null
-		}
-		if (obj instanceof Event) {
-			// "Label" for events will be "name"
-			if (id == "org.eventb.core.label") {
-				return CorePackage.Literals.EVENT_BNAMED__NAME
-			}
-			return null
-		}
-		if (obj instanceof Parameter) {
-			// "Identifier" for parameters will be "name"
-			if (id == "org.eventb.core.identifier") {
-				return CorePackage.Literals.EVENT_BNAMED__NAME
-			}
-			return null
-		}
-		if (obj instanceof Guard) {
-			// "Label" for guards will be "name"
-			if (id == "org.eventb.core.label") {
-				return CorePackage.Literals.EVENT_BNAMED__NAME
-			}
-			// "Predicate" for guards will be "predicate"
-			if (id == "org.eventb.core.predicate") {
-				return CorePackage.Literals.EVENT_BPREDICATE__PREDICATE				
-			}
-			return null
-		}
-		if (obj instanceof Action) {
-			// "Label" for actions will be "name"
-			if (id == "org.eventb.core.label") {
-				return CorePackage.Literals.EVENT_BNAMED__NAME
-			}
-			// "Assignment" for actions will be "action"
-			if (id == "org.eventb.core.assignment") {
-				return CorePackage.Literals.EVENT_BACTION__ACTION			
-			}
-			return null
-		}
-		if (obj instanceof Witness) {
-			// "Label" for witnesses will be "name"
-			if (id == "org.eventb.core.label") {
-				return CorePackage.Literals.EVENT_BNAMED__NAME
-			}
-			// "Predicate" for witnesses will be "predicate"
-			if (id == "org.eventb.core.predicate") {
-				return CorePackage.Literals.EVENT_BPREDICATE__PREDICATE				
-			}
-			return null
-		}
-		if (obj instanceof Variant) {
-			// "Expression" for variant will be "expression"
-			if (id == "org.eventb.core.expression") {
-				return CorePackage.Literals.EVENT_BEXPRESSION__EXPRESSION
-			}
-			return null
-		}
-		return null
-	}
-	
-	/**
-	 * Utility method to create an issue associated with an EObject from a Rodin
-	 * marker associated with the Rodin element corresponding to the EObject.
-	 * 
-	 * @param obj
-	 * 			The input EObject
-	 * @param rodinMarker
-	 * 			The input Rodin marker.
-	 * @author htson
-	 * @since 2.0
-	 */
-	def private createIssue(EObject obj, IMarker rodinMarker) {
-		val attributeType = RodinMarkerUtil.getAttributeType(rodinMarker);
+        if (evt.prefix.empty) {
+            val mchContainer = evt.eContainer.eContainer as Machine
+            val mchIncExtensions = mchContainer.extensions.filter(MachineInclusion)
+            for (ext : mchIncExtensions) {
+                if (ext.abstractMachine.events.contains(evt.synchronisedEvent)) {
+                    if (ext.prefixes.empty)
+                        return
+                    else
+                        warning('Prefixing should be applied to the synchronised event.', null)
+                }
+            }
+        }
+    }
+
+    /**
+     * Empty array of markers.
+     * 
+     * @since 2.0
+     */
+    val IMarker[] NO_MARKER = #[];
+
+    /**
+     * Utility method to find all Rodin markers associated with a machine root.
+     * @param mchRoot
+     * 			The input machine root.
+     * 
+     * @return An array of the Rodin markers associated with the input machine
+     * root.
+     * 
+     * @author htson
+     * @since 2.0 
+     */
+    def private IMarker[] findRodinMarkers(IMachineRoot mchRoot) throws CoreException {
+        val resource = mchRoot.getResource();
+        if (!resource.isAccessible()) {
+            return NO_MARKER;
+        }
+        return resource.findMarkers(RodinMarkerUtil.RODIN_PROBLEM_MARKER, true, IResource.DEPTH_INFINITE);
+    }
+
+    /**
+     * Utility method to get the EStructuralFeature corresponding to an
+     * attribute of an input EObject (of some Event-B elements), given the
+     * attribute type.
+     * 
+     * @param obj
+     * 			The input EObject
+     * @param attributeType
+     * 			The input attribute type
+     * @return The EStructuralFeature corresponding to the Attribute Type for
+     * 			the EObject. If no EStructuralFeature exists, return
+     * 			<code>null</code>. 
+     * 
+     * @author htson
+     * @since 2.0
+     */
+    // TODO This is probably incomplete
+    def private EStructuralFeature getFeature(
+        EObject obj,
+        IAttributeType attributeType // This is the Rodin Attribute Type
+    ) {
+        // TODO Colin: Is there a better way to do this
+        if (attributeType === null)
+            return null
+        val id = attributeType.id
+        if (obj instanceof Variable) {
+            // "Identifier" for variables will be "name"
+            if (id == "org.eventb.core.identifier")
+                return CorePackage.Literals.EVENT_BNAMED__NAME
+            return null
+        }
+        if (obj instanceof Invariant) {
+            // "Label" for invariants will be "name"
+            if (id == "org.eventb.core.label") {
+                return CorePackage.Literals.EVENT_BNAMED__NAME
+            }
+            // "Predicate" for invariants will be "predicate"
+            if (id == "org.eventb.core.predicate") {
+                return CorePackage.Literals.EVENT_BPREDICATE__PREDICATE
+            }
+            return null
+        }
+        if (obj instanceof Event) {
+            // "Label" for events will be "name"
+            if (id == "org.eventb.core.label") {
+                return CorePackage.Literals.EVENT_BNAMED__NAME
+            }
+            return null
+        }
+        if (obj instanceof Parameter) {
+            // "Identifier" for parameters will be "name"
+            if (id == "org.eventb.core.identifier") {
+                return CorePackage.Literals.EVENT_BNAMED__NAME
+            }
+            return null
+        }
+        if (obj instanceof Guard) {
+            // "Label" for guards will be "name"
+            if (id == "org.eventb.core.label") {
+                return CorePackage.Literals.EVENT_BNAMED__NAME
+            }
+            // "Predicate" for guards will be "predicate"
+            if (id == "org.eventb.core.predicate") {
+                return CorePackage.Literals.EVENT_BPREDICATE__PREDICATE
+            }
+            return null
+        }
+        if (obj instanceof Action) {
+            // "Label" for actions will be "name"
+            if (id == "org.eventb.core.label") {
+                return CorePackage.Literals.EVENT_BNAMED__NAME
+            }
+            // "Assignment" for actions will be "action"
+            if (id == "org.eventb.core.assignment") {
+                return CorePackage.Literals.EVENT_BACTION__ACTION
+            }
+            return null
+        }
+        if (obj instanceof Witness) {
+            // "Label" for witnesses will be "name"
+            if (id == "org.eventb.core.label") {
+                return CorePackage.Literals.EVENT_BNAMED__NAME
+            }
+            // "Predicate" for witnesses will be "predicate"
+            if (id == "org.eventb.core.predicate") {
+                return CorePackage.Literals.EVENT_BPREDICATE__PREDICATE
+            }
+            return null
+        }
+        if (obj instanceof Variant) {
+            // "Expression" for variant will be "expression"
+            if (id == "org.eventb.core.expression") {
+                return CorePackage.Literals.EVENT_BEXPRESSION__EXPRESSION
+            }
+            return null
+        }
+        return null
+    }
+
+    /**
+     * Utility method to create an issue associated with an EObject from a Rodin
+     * marker associated with the Rodin element corresponding to the EObject.
+     * 
+     * @param obj
+     * 			The input EObject
+     * @param rodinMarker
+     * 			The input Rodin marker.
+     * @author htson
+     * @since 2.0
+     */
+    def private createIssue(EObject obj, IMarker rodinMarker) {
+        val attributeType = RodinMarkerUtil.getAttributeType(rodinMarker);
         val attributes = rodinMarker.attributes
         val severity = attributes.get(IMarker.SEVERITY)
         var message = attributes.get(IMarker.MESSAGE)
-        
+
         var feature = getFeature(obj, attributeType)
         var elem = obj
         // If cannot find feature attach to the Machine name
-	    if (feature === null) {
-	        elem = getMachine(obj)
-	        if (elem !== null)
-	           feature = CorePackage.Literals.EVENT_BNAMED__NAME
-	        else
-	           elem = obj
-	    } else {
+        if (feature === null) {
+            elem = getMachine(obj)
+            if (elem !== null)
+                feature = CorePackage.Literals.EVENT_BNAMED__NAME
+            else
+                elem = obj
+        } else {
             // XText markers does not have information about "start" and "end"
             // at the moment. We include this information in the message and
             // "decode" it later when create the markers. 
@@ -302,16 +304,16 @@ class XMachineValidator extends AbstractXMachineValidator {
             val end = RodinMarkerUtil.getCharEnd(rodinMarker)
             if (start != -1) {
                 message = message + " (from " + start + " to " + end + ")"
-            }	        
-	    }
-		if (severity == IMarker.SEVERITY_ERROR)
-			error(message.toString, elem, feature)
-		else if (severity == IMarker.SEVERITY_WARNING)
-			warning(message.toString, elem, feature)
-		else
-			info(message.toString, elem, feature)
-	}
-    
+            }
+        }
+        if (severity == IMarker.SEVERITY_ERROR)
+            error(message.toString, elem, feature)
+        else if (severity == IMarker.SEVERITY_WARNING)
+            warning(message.toString, elem, feature)
+        else
+            info(message.toString, elem, feature)
+    }
+
     /**
      * Utility method to get the machine of an EObject. Return the Machine 
      * parent of the input element. Return <code>null</code> if there is no
@@ -322,247 +324,241 @@ class XMachineValidator extends AbstractXMachineValidator {
      * @author htson
      * @since 2.1
      */
-     def EObject getMachine(EObject object) {
-        if (object instanceof Machine)
-            return object
-        if (object instanceof Variable)
-            return object.eContainer
-        if (object instanceof Invariant)
-            return object.eContainer
-        if (object instanceof Event)
-            return object.eContainer
-        if (object instanceof Parameter)
-            return object.eContainer.eContainer
-        if (object instanceof Guard)
-            return object.eContainer.eContainer
-        if (object instanceof Action)
-            return object.eContainer.eContainer
-        if (object instanceof Witness)
-            return object.eContainer.eContainer
-        if (object instanceof Variant)
-            return object.eContainer.eContainer
-        
+    def EObject getMachine(EObject object) {
+        if (object instanceof EventBObject)
+            return object.getContaining(MachinePackage.Literals.MACHINE)
         return null
     }
 
-	/**
-	 * An "expensive" check to convert the Rodin Markers of an input Rodin
-	 * machine into issues for the corresponding XMachine.
-	 * 
-	 * @param mch
-	 * 			The input Rodini machine
-	 * 
-	 * @author htson
-	 * @since 2.0
-	 */
-	@Check(EXPENSIVE)
-	def checkRodinMarkers(Machine mch) {
-		val mchRoot = EventBEMFUtils.getRoot(mch)
-		val rodinMarkers = findRodinMarkers(mchRoot)
-		for (rodinMarker : rodinMarkers) {
-			val rodinElement = RodinMarkerUtil.getElement(rodinMarker)
-			var obj = getEObject(mch, rodinElement)
-			if (obj === null)
-				obj = mch
-			createIssue(obj, rodinMarker)
-		}
-	}
+    /**
+     * An "expensive" check to convert the Rodin Markers of an input Rodin
+     * machine into issues for the corresponding XMachine.
+     * 
+     * @param mch
+     * 			The input Rodini machine
+     * 
+     * @author htson
+     * @since 2.0
+     */
+    @Check(EXPENSIVE)
+    def checkRodinMarkers(Machine mch) {
+        val mchRoot = EventBEMFUtils.getRoot(mch)
+        val rodinMarkers = findRodinMarkers(mchRoot)
+        for (rodinMarker : rodinMarkers) {
+            val rodinElement = RodinMarkerUtil.getElement(rodinMarker)
+            var obj = getEObject(mch, rodinElement)
+            if (obj === null)
+                obj = mch
+            createIssue(obj, rodinMarker)
+        }
+    }
 
-	/**
-	 * A "Normal" check to clear the markers associated with the Rodin machine.
-	 * This is important as the markers generated as the consequence of
-	 * @link{#checkRodinMarkers(Machine)} are not cleared by when the file is
-	 * saved (hence they prevent the generator to run).
-	 * 
-	 * @author htson
-	 * @since 2.0
-	 */
-	@Check(NORMAL)
-	def clearRodinMarkers(Machine mch) {
-		// htson: This clear all markers associated with the XMachine file.
-		// We probably should register a new marker type and clear only those.
-		val uri = mch.eResource.URI
-		val resource = ResourcesPlugin.workspace.root.getFile(
-			new Path(uri.toPlatformString(true))
-		)
-		val markers = resource.findMarkers(null, true,
-				IResource.DEPTH_INFINITE);
-		for (marker : markers)
-			marker.delete
-				
-	}
+    /**
+     * A "Normal" check to clear the markers associated with the Rodin machine.
+     * This is important as the markers generated as the consequence of
+     * @link{#checkRodinMarkers(Machine)} are not cleared by when the file is
+     * saved (hence they prevent the generator to run).
+     * 
+     * @author htson
+     * @since 2.0
+     */
+    @Check(NORMAL)
+    def clearRodinMarkers(Machine mch) {
+        // htson: This clear all markers associated with the XMachine file.
+        // We probably should register a new marker type and clear only those.
+        val uri = mch.eResource.URI
+        val resource = ResourcesPlugin.workspace.root.getFile(
+            new Path(uri.toPlatformString(true))
+        )
+        val markers = resource.findMarkers(null, true, IResource.DEPTH_INFINITE);
+        for (marker : markers)
+            marker.delete
 
-	/**
-	 * Method to find the EObject in a machine corresponding to the input Rodin
-	 * object. This is the "identified" attribute such as "identifier", "label".
-	 * 
-	 * @param mch
-	 *			The input machine
-	 * @param rodinElement
-	 * 			The input Rodin element
-	 * @return the EObject corresponding to the input Rodin element within the
-	 *  		input machine or <code>null</code>  
-	 *
-	 */
-	// TODO These methods probably should go into EMFEventBUtils
-	def private EObject getEObject(Machine mch, IRodinElement rodinElement) {
-		if (rodinElement instanceof IMachineRoot) {
-			return mch
-		}
-		if (rodinElement instanceof IVariable) {
-			return findVariable(mch, rodinElement.identifierString)			
-		}
-		if (rodinElement instanceof IInvariant) {
-			return findInvariant(mch, rodinElement.label)
-		}
-		if (rodinElement instanceof IEvent) {
-			return findEvent(mch, rodinElement.label)
-		}
-		if (rodinElement instanceof IParameter) {
-			val event = rodinElement.parent as IEvent
-			return findParameter(mch, event.label, rodinElement.identifierString)
-		}
-		if (rodinElement instanceof IGuard) {
-			val event = rodinElement.parent as IEvent
-			return findGuard(mch, event.label, rodinElement.label)
-		}
-		if (rodinElement instanceof IAction) {
-			val event = rodinElement.parent as IEvent
-			return findAction(mch, event.label, rodinElement.label)
-		}
-		return null
-	}
-	
-	def private Variable findVariable(Machine mch, String name) {
-		val variables = mch.variables
-		for (variable : variables) {
-			if (variable.name == name)
-				return variable
-		}
-		return null
-	}
+    }
 
-	def private Invariant findInvariant(Machine mch, String label) {
-		val invariants = mch.invariants
-		for (invariant : invariants) {
-			if (invariant.name == label)
-				return invariant
-		}
-		return null
-	}
-	
-	def private Event findEvent(Machine mch, String label) {
-		val events = mch.events
-		for (event : events) {
-			if (event.name == label)
-				return event
-		}
-		return null
-	}
-	
-	def private Parameter findParameter(Machine mch, String eventLabel, String parameterName) {
-		val event = findEvent(mch, eventLabel)
-		if (event === null)
-			return null
-		val parameters = event.parameters
-		for (parameter : parameters) {
-			if (parameter.name == parameterName)
-				return parameter
-		}
-		return null		
-	}
+    /**
+     * Method to find the EObject in a machine corresponding to the input Rodin
+     * object. This is the "identified" attribute such as "identifier", "label".
+     * 
+     * @param mch
+     * 		The input machine
+     * @param rodinElement
+     * 			The input Rodin element
+     * @return the EObject corresponding to the input Rodin element within the
+     *  		input machine or <code>null</code>  
+     * 
+     */
+    // TODO These methods probably should go into EMFEventBUtils
+    def private EObject getEObject(Machine mch, IRodinElement rodinElement) {
+        if (rodinElement instanceof IMachineRoot) {
+            return mch
+        }
+        if (rodinElement instanceof IVariable) {
+            return findVariable(mch, rodinElement.identifierString)
+        }
+        if (rodinElement instanceof IInvariant) {
+            return findInvariant(mch, rodinElement.label)
+        }
+        if (rodinElement instanceof IEvent) {
+            return findEvent(mch, rodinElement.label)
+        }
+        if (rodinElement instanceof IParameter) {
+            val event = rodinElement.parent as IEvent
+            return findParameter(mch, event.label, rodinElement.identifierString)
+        }
+        if (rodinElement instanceof IGuard) {
+            val event = rodinElement.parent as IEvent
+            return findGuard(mch, event.label, rodinElement.label)
+        }
+        if (rodinElement instanceof IAction) {
+            val event = rodinElement.parent as IEvent
+            return findAction(mch, event.label, rodinElement.label)
+        }
+        return null
+    }
 
-	def private Guard findGuard(Machine mch, String eventLabel, String guardLabel) {
-		val event = findEvent(mch, eventLabel)
-		if (event === null)
-			return null
-		val guards = event.guards
-		for (guard : guards) {
-			if (guard.name == guardLabel)
-				return guard
-		}
-		return null		
-	}
+    def private Variable findVariable(Machine mch, String name) {
+        val variables = mch.variables
+        for (variable : variables) {
+            if (variable.name == name)
+                return variable
+        }
+        return null
+    }
 
-	def private Action findAction(Machine mch, String eventLabel, String actionLabel) {
-		val event = findEvent(mch, eventLabel)
-		if (event === null)
-			return null
-		val actions = event.actions
-		for (action : actions) {
-			if (action.name == actionLabel)
-				return action
-		}
-		return null		
-	}
+    def private Invariant findInvariant(Machine mch, String label) {
+        val invariants = mch.invariants
+        for (invariant : invariants) {
+            if (invariant.name == label)
+                return invariant
+        }
+        return null
+    }
 
-	/**
-	 * Check for untranslated predicates by comparing the translated string
-	 * with the predicate. Raise a warning with code
-	 * {@link IValidationIssueCode#UNTRANSLATE_PREDICATE}. The code is used for
-	 * providing quick fixes.
-	 * 
-	 * @param obj 
-	 * 		an Event-B predicate EObject.
-	 * @author htson
-	 * @see IValidationIssueCode
-	 * @since 2.0
-	 */
-	@Check
-	def untranslatedPredicate(EventBPredicate obj) {
-		val predicate = obj.predicate
-		val translated = RodinKeyboardCore.translate(predicate)
-		if (predicate != translated)
-			warning("Untranslated Predicate: " + predicate, obj,
-				CorePackage.Literals.EVENT_BPREDICATE__PREDICATE,
-				IValidationIssueCode.UNTRANSLATED_PREDICATE, predicate, translated
-			)
-	}
+    def private Event findEvent(Machine mch, String label) {
+        val events = mch.events
+        for (event : events) {
+            if (event.name == label)
+                return event
+        }
+        return null
+    }
 
-	/**
-	 * Check for untranslated expressions by comparing the translated string
-	 * with the expression. Raise a warning with code
-	 * {@link IValidationIssueCode#UNTRANSLATE_EXPRESSION}. The code is used for
-	 * providing quick fixes.
-	 * 
-	 * @param obj 
-	 * 		an Event-B expression EObject.
-	 * @author htson
-	 * @see IValidationIssueCode
-	 * @since 2.0
-	 */
-	@Check
-	def untranslatedExpression(EventBExpression obj) {
-		val expression = obj.expression
-		val translated = RodinKeyboardCore.translate(expression)
-		if (expression != translated)
-			warning("Untranslated Expression: " + expression, obj,
-				CorePackage.Literals.EVENT_BEXPRESSION__EXPRESSION,
-				IValidationIssueCode.UNTRANSLATED_EXPRESSION, expression, translated
-			)
-	}
+    def private Parameter findParameter(Machine mch, String eventLabel, String parameterName) {
+        val event = findEvent(mch, eventLabel)
+        if (event === null)
+            return null
+        val parameters = event.parameters
+        for (parameter : parameters) {
+            if (parameter.name == parameterName)
+                return parameter
+        }
+        return null
+    }
 
-	/**
-	 * Check for untranslated assignments by comparing the translated string
-	 * with the assignment. Raise a warning with code
-	 * {@link IValidationIssueCode#UNTRANSLATE_ASSIGNMENT}. The code is used for
-	 * providing quick fixes.
-	 * 
-	 * @param obj 
-	 * 		an Event-B action EObject.
-	 * @author htson
-	 * @see IValidationIssueCode
-	 * @since 2.0
-	 */
-	@Check
-	def untranslatedAssignment(EventBAction obj) {
-		val action = obj.action
-		val translated = RodinKeyboardCore.translate(action)
-		if (action != translated)
-			warning("Untranslated Assignment: " + action, obj,
-				CorePackage.Literals.EVENT_BACTION__ACTION,
-				IValidationIssueCode.UNTRANSLATED_ASSIGNMENT, action, translated
-			)
-	}
+    def private Guard findGuard(Machine mch, String eventLabel, String guardLabel) {
+        val event = findEvent(mch, eventLabel)
+        if (event === null)
+            return null
+        val guards = event.guards
+        for (guard : guards) {
+            if (guard.name == guardLabel)
+                return guard
+        }
+        return null
+    }
+
+    def private Action findAction(Machine mch, String eventLabel, String actionLabel) {
+        val event = findEvent(mch, eventLabel)
+        if (event === null)
+            return null
+        val actions = event.actions
+        for (action : actions) {
+            if (action.name == actionLabel)
+                return action
+        }
+        return null
+    }
+
+    /**
+     * Check for untranslated predicates by comparing the translated string
+     * with the predicate. Raise a warning with code
+     * {@link IValidationIssueCode#UNTRANSLATE_PREDICATE}. The code is used for
+     * providing quick fixes.
+     * 
+     * @param obj 
+     * 		an Event-B predicate EObject.
+     * @author htson
+     * @see IValidationIssueCode
+     * @since 2.0
+     */
+    @Check
+    def untranslatedPredicate(EventBPredicate obj) {
+        val predicate = obj.predicate
+        val translated = RodinKeyboardCore.translate(predicate)
+        if (predicate != translated)
+            warning(
+                "Untranslated Predicate: " + predicate,
+                obj,
+                CorePackage.Literals.EVENT_BPREDICATE__PREDICATE,
+                IValidationIssueCode.UNTRANSLATED_PREDICATE,
+                predicate,
+                translated
+            )
+    }
+
+    /**
+     * Check for untranslated expressions by comparing the translated string
+     * with the expression. Raise a warning with code
+     * {@link IValidationIssueCode#UNTRANSLATE_EXPRESSION}. The code is used for
+     * providing quick fixes.
+     * 
+     * @param obj 
+     * 		an Event-B expression EObject.
+     * @author htson
+     * @see IValidationIssueCode
+     * @since 2.0
+     */
+    @Check
+    def untranslatedExpression(EventBExpression obj) {
+        val expression = obj.expression
+        val translated = RodinKeyboardCore.translate(expression)
+        if (expression != translated)
+            warning(
+                "Untranslated Expression: " + expression,
+                obj,
+                CorePackage.Literals.EVENT_BEXPRESSION__EXPRESSION,
+                IValidationIssueCode.UNTRANSLATED_EXPRESSION,
+                expression,
+                translated
+            )
+    }
+
+    /**
+     * Check for untranslated assignments by comparing the translated string
+     * with the assignment. Raise a warning with code
+     * {@link IValidationIssueCode#UNTRANSLATE_ASSIGNMENT}. The code is used for
+     * providing quick fixes.
+     * 
+     * @param obj 
+     * 		an Event-B action EObject.
+     * @author htson
+     * @see IValidationIssueCode
+     * @since 2.0
+     */
+    @Check
+    def untranslatedAssignment(EventBAction obj) {
+        val action = obj.action
+        val translated = RodinKeyboardCore.translate(action)
+        if (action != translated)
+            warning(
+                "Untranslated Assignment: " + action,
+                obj,
+                CorePackage.Literals.EVENT_BACTION__ACTION,
+                IValidationIssueCode.UNTRANSLATED_ASSIGNMENT,
+                action,
+                translated
+            )
+    }
 
 }

--- a/ac.soton.xeventb.xmachine/xtend-gen/ac/soton/xeventb/xmachine/validation/XMachineValidator.java
+++ b/ac.soton.xeventb.xmachine/xtend-gen/ac/soton/xeventb/xmachine/validation/XMachineValidator.java
@@ -70,8 +70,9 @@ import org.rodinp.keyboard.core.RodinKeyboardCore;
  * 
  * @author dana - Initial implementation
  * @author htson - Added support for lifting Rodin issues into XMachine
- * @version 1.0
+ * @version 1.1
  * @since 1.0
+ * @see XMachineMarkerModule
  */
 @SuppressWarnings("all")
 public class XMachineValidator extends AbstractXMachineValidator {
@@ -309,34 +310,85 @@ public class XMachineValidator extends AbstractXMachineValidator {
   private void createIssue(final EObject obj, final IMarker rodinMarker) {
     try {
       final IAttributeType attributeType = RodinMarkerUtil.getAttributeType(rodinMarker);
-      final EStructuralFeature feature = this.getFeature(obj, attributeType);
       final Map<String, Object> attributes = rodinMarker.getAttributes();
       final Object severity = attributes.get(IMarker.SEVERITY);
-      final int start = RodinMarkerUtil.getCharStart(rodinMarker);
-      final int end = RodinMarkerUtil.getCharEnd(rodinMarker);
       Object message = attributes.get(IMarker.MESSAGE);
-      if ((start != (-1))) {
-        String _plus = (message + " (from ");
-        String _plus_1 = (_plus + Integer.valueOf(start));
-        String _plus_2 = (_plus_1 + " to ");
-        String _plus_3 = (_plus_2 + Integer.valueOf(end));
-        String _plus_4 = (_plus_3 + ")");
-        message = _plus_4;
+      EStructuralFeature feature = this.getFeature(obj, attributeType);
+      EObject elem = obj;
+      if ((feature == null)) {
+        elem = this.getMachine(obj);
+        if ((elem != null)) {
+          feature = CorePackage.Literals.EVENT_BNAMED__NAME;
+        } else {
+          elem = obj;
+        }
+      } else {
+        final int start = RodinMarkerUtil.getCharStart(rodinMarker);
+        final int end = RodinMarkerUtil.getCharEnd(rodinMarker);
+        if ((start != (-1))) {
+          String _plus = (message + " (from ");
+          String _plus_1 = (_plus + Integer.valueOf(start));
+          String _plus_2 = (_plus_1 + " to ");
+          String _plus_3 = (_plus_2 + Integer.valueOf(end));
+          String _plus_4 = (_plus_3 + ")");
+          message = _plus_4;
+        }
       }
       boolean _equals = Objects.equal(severity, Integer.valueOf(IMarker.SEVERITY_ERROR));
       if (_equals) {
-        this.error(message.toString(), obj, feature);
+        this.error(message.toString(), elem, feature);
       } else {
         boolean _equals_1 = Objects.equal(severity, Integer.valueOf(IMarker.SEVERITY_WARNING));
         if (_equals_1) {
-          this.warning(message.toString(), obj, feature);
+          this.warning(message.toString(), elem, feature);
         } else {
-          this.info(message.toString(), obj, feature);
+          this.info(message.toString(), elem, feature);
         }
       }
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
     }
+  }
+  
+  /**
+   * Utility method to get the machine of an EObject. Return the Machine
+   * parent of the input element. Return <code>null</code> if there is no
+   * Machine containing the input element.
+   * 
+   * @param obj
+   *          The input EObject
+   * @author htson
+   * @since 2.1
+   */
+  public EObject getMachine(final EObject object) {
+    if ((object instanceof Machine)) {
+      return object;
+    }
+    if ((object instanceof Variable)) {
+      return ((Variable)object).eContainer();
+    }
+    if ((object instanceof Invariant)) {
+      return ((Invariant)object).eContainer();
+    }
+    if ((object instanceof Event)) {
+      return ((Event)object).eContainer();
+    }
+    if ((object instanceof Parameter)) {
+      return ((Parameter)object).eContainer().eContainer();
+    }
+    if ((object instanceof Guard)) {
+      return ((Guard)object).eContainer().eContainer();
+    }
+    if ((object instanceof Action)) {
+      return ((Action)object).eContainer().eContainer();
+    }
+    if ((object instanceof Witness)) {
+      return ((Witness)object).eContainer().eContainer();
+    }
+    if ((object instanceof Variant)) {
+      return ((Variant)object).eContainer().eContainer();
+    }
+    return null;
   }
   
   /**

--- a/ac.soton.xeventb.xmachine/xtend-gen/ac/soton/xeventb/xmachine/validation/XMachineValidator.java
+++ b/ac.soton.xeventb.xmachine/xtend-gen/ac/soton/xeventb/xmachine/validation/XMachineValidator.java
@@ -47,12 +47,14 @@ import org.eventb.emf.core.AbstractExtension;
 import org.eventb.emf.core.CorePackage;
 import org.eventb.emf.core.EventBAction;
 import org.eventb.emf.core.EventBExpression;
+import org.eventb.emf.core.EventBObject;
 import org.eventb.emf.core.EventBPredicate;
 import org.eventb.emf.core.machine.Action;
 import org.eventb.emf.core.machine.Event;
 import org.eventb.emf.core.machine.Guard;
 import org.eventb.emf.core.machine.Invariant;
 import org.eventb.emf.core.machine.Machine;
+import org.eventb.emf.core.machine.MachinePackage;
 import org.eventb.emf.core.machine.Parameter;
 import org.eventb.emf.core.machine.Variable;
 import org.eventb.emf.core.machine.Variant;
@@ -136,7 +138,8 @@ public class XMachineValidator extends AbstractXMachineValidator {
         if (_isEmpty) {
           String _name = inc.getAbstractMachine().getName();
           String _plus = ("Prefixing is not defined for " + _name);
-          String _plus_1 = (_plus + ". Possible synchronisation ambiguity. ");
+          String _plus_1 = (_plus + 
+            ". Possible synchronisation ambiguity. ");
           this.warning(_plus_1, null);
         }
       }
@@ -196,8 +199,7 @@ public class XMachineValidator extends AbstractXMachineValidator {
     if (_not) {
       return this.NO_MARKER;
     }
-    return resource.findMarkers(RodinMarkerUtil.RODIN_PROBLEM_MARKER, true, 
-      IResource.DEPTH_INFINITE);
+    return resource.findMarkers(RodinMarkerUtil.RODIN_PROBLEM_MARKER, true, IResource.DEPTH_INFINITE);
   }
   
   /**
@@ -361,32 +363,8 @@ public class XMachineValidator extends AbstractXMachineValidator {
    * @since 2.1
    */
   public EObject getMachine(final EObject object) {
-    if ((object instanceof Machine)) {
-      return object;
-    }
-    if ((object instanceof Variable)) {
-      return ((Variable)object).eContainer();
-    }
-    if ((object instanceof Invariant)) {
-      return ((Invariant)object).eContainer();
-    }
-    if ((object instanceof Event)) {
-      return ((Event)object).eContainer();
-    }
-    if ((object instanceof Parameter)) {
-      return ((Parameter)object).eContainer().eContainer();
-    }
-    if ((object instanceof Guard)) {
-      return ((Guard)object).eContainer().eContainer();
-    }
-    if ((object instanceof Action)) {
-      return ((Action)object).eContainer().eContainer();
-    }
-    if ((object instanceof Witness)) {
-      return ((Witness)object).eContainer().eContainer();
-    }
-    if ((object instanceof Variant)) {
-      return ((Variant)object).eContainer().eContainer();
+    if ((object instanceof EventBObject)) {
+      return ((EventBObject)object).getContaining(MachinePackage.Literals.MACHINE);
     }
     return null;
   }
@@ -438,8 +416,7 @@ public class XMachineValidator extends AbstractXMachineValidator {
       String _platformString = uri.toPlatformString(true);
       Path _path = new Path(_platformString);
       final IFile resource = _root.getFile(_path);
-      final IMarker[] markers = resource.findMarkers(null, true, 
-        IResource.DEPTH_INFINITE);
+      final IMarker[] markers = resource.findMarkers(null, true, IResource.DEPTH_INFINITE);
       for (final IMarker marker : markers) {
         marker.delete();
       }
@@ -453,7 +430,7 @@ public class XMachineValidator extends AbstractXMachineValidator {
    * object. This is the "identified" attribute such as "identifier", "label".
    * 
    * @param mch
-   * 			The input machine
+   * 		The input machine
    * @param rodinElement
    * 			The input Rodin element
    * @return the EObject corresponding to the input Rodin element within the
@@ -596,7 +573,8 @@ public class XMachineValidator extends AbstractXMachineValidator {
     final String translated = RodinKeyboardCore.translate(predicate);
     boolean _notEquals = (!Objects.equal(predicate, translated));
     if (_notEquals) {
-      this.warning(("Untranslated Predicate: " + predicate), obj, 
+      this.warning(
+        ("Untranslated Predicate: " + predicate), obj, 
         CorePackage.Literals.EVENT_BPREDICATE__PREDICATE, 
         IValidationIssueCode.UNTRANSLATED_PREDICATE, predicate, translated);
     }
@@ -620,7 +598,8 @@ public class XMachineValidator extends AbstractXMachineValidator {
     final String translated = RodinKeyboardCore.translate(expression);
     boolean _notEquals = (!Objects.equal(expression, translated));
     if (_notEquals) {
-      this.warning(("Untranslated Expression: " + expression), obj, 
+      this.warning(
+        ("Untranslated Expression: " + expression), obj, 
         CorePackage.Literals.EVENT_BEXPRESSION__EXPRESSION, 
         IValidationIssueCode.UNTRANSLATED_EXPRESSION, expression, translated);
     }
@@ -644,7 +623,8 @@ public class XMachineValidator extends AbstractXMachineValidator {
     final String translated = RodinKeyboardCore.translate(action);
     boolean _notEquals = (!Objects.equal(action, translated));
     if (_notEquals) {
-      this.warning(("Untranslated Assignment: " + action), obj, 
+      this.warning(
+        ("Untranslated Assignment: " + action), obj, 
         CorePackage.Literals.EVENT_BACTION__ACTION, 
         IValidationIssueCode.UNTRANSLATED_ASSIGNMENT, action, translated);
     }


### PR DESCRIPTION
The markers are now attached to the name of the XMachine or XContext if there are no element/feature found corresponding to the original issue